### PR TITLE
More flexible 

### DIFF
--- a/llm_azure_openai.py
+++ b/llm_azure_openai.py
@@ -16,7 +16,7 @@ from enum import Enum
 # import httpx
 import openai
 import os
-from azure.identity import EnvironmentCredential, get_bearer_token_provider
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 from pydantic import field_validator, Field
 
@@ -49,12 +49,14 @@ def register_models(register):
         can_stream = azure_model.get("can_stream", True)
         allows_system_prompt = azure_model.get("allows_system_prompt", True)
         use_azure_ad = azure_model.get("use_azure_ad", True)
+        scope = azure_model.get("scope", "https://cognitiveservices.azure.com/.default")
 
         # Set up Azure AD token provider if specified
         azure_ad_token_provider = None
         if use_azure_ad:
             azure_ad_token_provider = get_bearer_token_provider(
-                EnvironmentCredential(), "https://cognitiveservices.azure.com/.default"
+                DefaultAzureCredential(),
+                scope
             )
 
         if can_stream is False:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "llm>=0.23",
     "httpx",
     "ijson",
-    "azure-identity"
+    "azure-identity>=1.10.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR replaces `EnvironmentCredential()` with `DefaultAzureCredential()` which is more versatile (see https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#defaultazurecredential).

>As of version 1.10.1, DefaultAzureCredential attempts to authenticate with all developer tool credentials until one succeeds, regardless of any errors previous developer tool credentials experienced. 


 This PR also allows to specify the scope to use in the config file.